### PR TITLE
point jsnext:main to src/index.js for rollup.js (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.0",
   "description": "Wraps react-redux up for Preact, without preact-compat",
   "main": "dist/preact-redux.js",
+  "jsnext:main": "src/index.js",
   "src:main": "src/index.js",
   "minified:main": "dist/preact-redux.min.js",
   "scripts": {


### PR DESCRIPTION
This will let other packages do:
```javascript
import { connect } from 'preact-redux'
```
See https://github.com/rollup/rollup/wiki/jsnext:main, and<br/>https://github.com/developit/preact/blob/master/package.json#L7.