### PR TITLE
Fix #6: DONOTMERGE: Add react-redux typescript definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   "minified:main": "dist/preact-redux.min.js",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "NODE_ENV=production npm-run-all clean transpile minify size",
+    "build": "NODE_ENV=production npm-run-all clean transpile copy-typescript-definition minify size",
     "transpile": "rollup -c rollup.config.js -m ${npm_package_main}.map -f umd -n $npm_package_amdName $npm_package_src_main",
     "minify": "uglifyjs $npm_package_main --define NODE_ENV=production --pure-funcs classCallCheck Object.defineProperty Object.freeze invariant warning -c unsafe,collapse_vars,evaluate,screw_ie8,loops,keep_fargs=false,pure_getters,unused,dead_code -m -o $npm_package_minified_main -p relative --in-source-map ${npm_package_main}.map --source-map ${npm_package_minified_main}.map",
     "size": "size=$(gzip-size $npm_package_minified_main) && echo \"gzip size: $size / $(pretty-bytes $size)\"",
     "test": "NODE_ENV=development npm-run-all lint transpile test:karma",
     "lint": "eslint {src,test}",
+    "copy-typescript-definition": "copyfiles -f src/preact-redux.d.ts dist",
+
     "test:karma": "karma start --single-run",
     "test:watch": "karma start",
     "prepublish": "npm-run-all build test",
@@ -30,6 +32,7 @@
     "type": "git",
     "url": "git+https://github.com/developit/preact-redux.git"
   },
+  "typings": "dist/preact-redux.d.ts",
   "bugs": {
     "url": "https://github.com/developit/preact-redux/issues"
   },
@@ -39,6 +42,7 @@
     "redux": ">=2"
   },
   "devDependencies": {
+    "@types/redux": "^3.6.0",
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",
     "babel-eslint": "^6.1.2",
@@ -54,6 +58,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
+    "copyfiles": "^1.0.0",
     "diff": "^3.0.0",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",

--- a/src/preact-redux.d.ts
+++ b/src/preact-redux.d.ts
@@ -1,0 +1,66 @@
+// Based on the DefinitelyTyped typings for react-redux (2.1.2)
+
+/// <reference types="preact" />
+/// <reference types="redux" />
+
+declare module "preact-redux" {
+  import { Component } from 'preact';
+  import { Store, Dispatch, ActionCreator } from 'redux';
+
+  export abstract class ElementClass extends Component<any, any> { }
+  export interface ClassDecorator {
+    <T extends (typeof ElementClass)>(component: T): T
+  }
+
+  /**
+   * Connects a React component to a Redux store.
+   * @param mapStateToProps
+   * @param mapDispatchToProps
+   * @param mergeProps
+   * @param options
+     */
+  export function connect(mapStateToProps?: MapStateToProps,
+                          mapDispatchToProps?: MapDispatchToPropsFunction|MapDispatchToPropsObject,
+                          mergeProps?: MergeProps,
+                          options?: Options): ClassDecorator;
+
+  interface MapStateToProps {
+    (state: any, ownProps?: any): any;
+  }
+
+  interface MapDispatchToPropsFunction {
+    (dispatch: Dispatch<any>, ownProps?: any): any;
+  }
+
+  interface MapDispatchToPropsObject {
+    [name: string]: ActionCreator<any>;
+  }
+
+  interface MergeProps {
+    (stateProps: any, dispatchProps: any, ownProps: any): any;
+  }
+
+  interface Options {
+    /**
+     * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
+     * preventing unnecessary updates, assuming that the component is a “pure” component
+     * and does not rely on any input or state other than its props and the selected Redux store’s state.
+     * Defaults to true.
+     * @default true
+     */
+    pure: boolean;
+  }
+
+  export interface Property {
+    /**
+     * The single Redux store in your application.
+     */
+    store?: Store<any>;
+    children?: Function;
+  }
+
+  /**
+   * Makes the Redux store available to the connect() calls in the component hierarchy below.
+   */
+  export abstract class Provider extends Component<Property, {}> { }
+}


### PR DESCRIPTION
This is a pretty cheesy solution.  But hey!

Seems to have trouble with stateless functional components, need to parity check the support against react before it's ready, but at least it gives everyone a chance to have a look at what I'm doing.