### PR TITLE
Update preact-redux.d.ts

### DIFF
--- a/src/preact-redux.d.ts
+++ b/src/preact-redux.d.ts
@@ -275,5 +275,5 @@ export interface ProviderProps {
  * Makes the Redux store available to the connect() calls in the component hierarchy below.
  */
 export class Provider extends Component<ProviderProps, {}> {
-    render(props: ProviderProps): VNode
+    render(props?: ProviderProps): VNode
 }


### PR DESCRIPTION
fixes error

There is such error with: 
- preact@8.2.5
- preact-redux@2.0.3
- typescrupt@2.5.2

```
[at-loader] ./node_modules/preact-redux/src/preact-redux.d.ts:277:14
    TS2415: Class 'Provider' incorrectly extends base class 'Component<ProviderProps, {}>'.
  Types of property 'render' are incompatible.
    Type '(props: ProviderProps) => VNode' is not assignable to type '(props?: (ProviderProps & ComponentProps<this>) | undefined, state?: {} | undefined, context?: an...'.
      Types of parameters 'props' and 'props' are incompatible.
        Type '(ProviderProps & ComponentProps<this>) | undefined' is not assignable to type 'ProviderProps'.
          Type 'undefined' is not assignable to type 'ProviderProps'.
```