### PR TITLE
Updated TypeScript definitions and added tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "transpile:es": "rollup -c --environment FORMAT:es",
     "minify": "uglifyjs dist/preact-redux.js --define NODE_ENV=production --pure-funcs classCallCheck Object.defineProperty Object.freeze invariant warning -c unsafe,collapse_vars,evaluate,screw_ie8,loops,keep_fargs=false,pure_getters,unused,dead_code -m -o dist/preact-redux.min.js -p relative --in-source-map dist/preact-redux.js.map --source-map dist/preact-redux.min.js.map",
     "size": "gzip-size dist/preact-redux.min.js",
-    "test": "cross-env NODE_ENV=development npm-run-all lint transpile:* test:karma",
+    "test:ts": "tsc -p test/ts/",
+    "test": "cross-env NODE_ENV=development npm-run-all lint transpile:* test:karma test:ts",
     "lint": "eslint {src,test}",
     "test:karma": "karma start --single-run",
     "test:watch": "karma start",
@@ -93,6 +94,7 @@
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",
     "uglify-js": "^2.8.22",
-    "webpack": "^2.3.3"
+    "webpack": "^2.3.3",
+    "typescript":"^2.6.2"
   }
 }

--- a/src/preact-redux.d.ts
+++ b/src/preact-redux.d.ts
@@ -1,45 +1,70 @@
-// Type definitions for preact-redux 2.0.1
+// Type definitions for preact-redux copied from
+
+// Type definitions for react-redux 5.0.8
+// Project: https://github.com/rackt/react-redux
 // Definitions by: Qubo <https://github.com/tkqubo>,
 //                 Thomas Hasner <https://github.com/thasner>,
 //                 Kenzie Togami <https://github.com/kenzierocks>,
 //                 Curits Layne <https://github.com/clayne11>
 //                 Frank Tan <https://github.com/tansongyang>
-//                 Daniil Kolesnik <https://github.com/rand0me>
+//                 Nicholas Boll <https://github.com/nicholasboll>
+//                 Dibyo Majumdar <https://github.com/mdibyo>
+//                 Prashant Deva <https://github.com/pdeva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import { AnyComponent, Component, ComponentConstructor, VNode } from 'preact';
-import { Store, Dispatch, ActionCreator } from 'redux';
+// Known Issue:
+// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
+// they are decorating. Due to this, if you are using @connect() decorator in your code,
+// you will see a bunch of errors from TypeScript. The current workaround is to use connect() as a function call on
+// a separate line instead of as a decorator. Discussed in this github issue:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796
+
+import * as Preact from 'preact'
+import * as Redux from 'redux'
+
+type ComponentClass<P> = Preact.ComponentConstructor<P, {}>
+type StatelessComponent<P> = Preact.FunctionalComponent<P>
+type Component<P> = Preact.AnyComponent<P, {}>
+type ReactNode = Preact.VNode
+type Store<S> = Redux.Store<S>
+type Dispatch<S> = Redux.Dispatch<S>
+type ActionCreator<A> = Redux.ActionCreator<A>
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+type Diff<T extends string, U extends string> = ({ [P in T]: P } &
+  { [P in U]: never } & { [x: string]: never })[T]
+type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
 
 export interface DispatchProp<S> {
-  dispatch?: Dispatch<S>;
+  dispatch?: Dispatch<S>
 }
 
 interface AdvancedComponentDecorator<TProps, TOwnProps> {
-    (component: AnyComponent<TProps, {}>): ComponentConstructor<TOwnProps, {}>;
+  (component: Component<TProps>): ComponentClass<TOwnProps>
 }
 
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
-export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
-    <P extends TInjectedProps>(
-        component: AnyComponent<P, {}>
-    ): ComponentConstructor<Omit<P, keyof TInjectedProps> & TNeedsProps, {}>
+export interface InferableComponentEnhancerWithProps<
+  TInjectedProps,
+  TNeedsProps
+> {
+  <P extends TInjectedProps>(component: Component<P>): ComponentClass<
+    Omit<P, keyof TInjectedProps> & TNeedsProps
+  > & { WrappedComponent: Component<P> }
 }
 
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during
 // render.
-export type InferableComponentEnhancer<TInjectedProps> =
-    InferableComponentEnhancerWithProps<TInjectedProps, {}>
+export type InferableComponentEnhancer<
+  TInjectedProps
+> = InferableComponentEnhancerWithProps<TInjectedProps, {}>
 
 /**
- * Connects a Preact component to a Redux store.
+ * Connects a React component to a Redux store.
  *
  * - Without arguments, just wraps the component, without changing the behavior / props
  *
@@ -57,134 +82,208 @@ export type InferableComponentEnhancer<TInjectedProps> =
  * @param mergeProps
  * @param options
  */
-export declare function connect(): InferableComponentEnhancer<DispatchProp<any>>;
+export interface Connect {
+  (): InferableComponentEnhancer<DispatchProp<any>>
 
-export declare function connect<TStateProps, no_dispatch, TOwnProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<TStateProps & DispatchProp<any>, TOwnProps>;
+  <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = {}>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & DispatchProp<any>,
+    TOwnProps
+  >
 
-export declare function connect<no_state, TDispatchProps, TOwnProps>(
+  <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>;
+  ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
 
-export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
 
-export declare function connect<TStateProps, no_dispatch, TOwnProps, TMergedProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+  <
+    TStateProps = {},
+    no_dispatch = {},
+    TOwnProps = {},
+    TMergedProps = {},
+    State = {}
+  >(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
     mapDispatchToProps: null | undefined,
-    mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+    mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-export declare function connect<no_state, TDispatchProps, TOwnProps, TMergedProps>(
+  <no_state = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-    mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+    mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-export declare function connect<no_state, no_dispatch, TOwnProps, TMergedProps>(
+  <no_state = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: null | undefined,
-    mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+    mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+  <
+    TStateProps = {},
+    TDispatchProps = {},
+    TOwnProps = {},
+    TMergedProps = {},
+    State = {}
+  >(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-    mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+    mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-export declare function connect<TStateProps, no_dispatch, TOwnProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+  <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = {}>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
     mapDispatchToProps: null | undefined,
     mergeProps: null | undefined,
-    options: Options<TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<DispatchProp<any> & TStateProps, TOwnProps>;
+    options: Options<State, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    DispatchProp<any> & TStateProps,
+    TOwnProps
+  >
 
-export declare function connect<no_state, TDispatchProps, TOwnProps>(
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
-    options: Options<no_state, TOwnProps>
-): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>;
+    options: Options<{}, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
 
-export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
-    options: Options<TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
+    options: Options<State, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
 
-export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+  <
+    TStateProps = {},
+    TDispatchProps = {},
+    TOwnProps = {},
+    TMergedProps = {},
+    State = {}
+  >(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-    mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
-    options: Options<TStateProps, TOwnProps, TMergedProps>
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
-
-interface MapStateToProps<TStateProps, TOwnProps> {
-    (state: any, ownProps: TOwnProps): TStateProps;
+    mergeProps: MergeProps<
+      TStateProps,
+      TDispatchProps,
+      TOwnProps,
+      TMergedProps
+    >,
+    options: Options<State, TStateProps, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 }
 
-interface MapStateToPropsFactory<TStateProps, TOwnProps> {
-    (initialState: any, ownProps: TOwnProps): MapStateToProps<TStateProps, TOwnProps>;
+/**
+ * The connect function. See {@type Connect} for details.
+ */
+export declare const connect: Connect
+
+interface MapStateToProps<TStateProps, TOwnProps, State> {
+  (state: State, ownProps: TOwnProps): TStateProps
 }
 
-type MapStateToPropsParam<TStateProps, TOwnProps> = MapStateToProps<TStateProps, TOwnProps> | MapStateToPropsFactory<TStateProps, TOwnProps>;
+interface MapStateToPropsFactory<TStateProps, TOwnProps, State> {
+  (initialState: State, ownProps: TOwnProps): MapStateToProps<
+    TStateProps,
+    TOwnProps,
+    State
+  >
+}
+
+type MapStateToPropsParam<TStateProps, TOwnProps, State> =
+  | MapStateToPropsFactory<TStateProps, TOwnProps, State>
+  | MapStateToProps<TStateProps, TOwnProps, State>
+  | null
+  | undefined
 
 interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
-    (dispatch: Dispatch<any>, ownProps: TOwnProps): TDispatchProps;
+  (dispatch: Dispatch<any>, ownProps: TOwnProps): TDispatchProps
 }
 
 type MapDispatchToProps<TDispatchProps, TOwnProps> =
-    MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | TDispatchProps;
+  | MapDispatchToPropsFunction<TDispatchProps, TOwnProps>
+  | TDispatchProps
 
 interface MapDispatchToPropsFactory<TDispatchProps, TOwnProps> {
-    (dispatch: Dispatch<any>, ownProps: TOwnProps): MapDispatchToProps<TDispatchProps, TOwnProps>;
+  (dispatch: Dispatch<any>, ownProps: TOwnProps): MapDispatchToProps<
+    TDispatchProps,
+    TOwnProps
+  >
 }
 
-type MapDispatchToPropsParam<TDispatchProps, TOwnProps> = MapDispatchToProps<TDispatchProps, TOwnProps> | MapDispatchToPropsFactory<TDispatchProps, TOwnProps>;
+type MapDispatchToPropsParam<TDispatchProps, TOwnProps> =
+  | MapDispatchToPropsFactory<TDispatchProps, TOwnProps>
+  | MapDispatchToProps<TDispatchProps, TOwnProps>
 
 interface MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> {
-    (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergedProps;
+  (
+    stateProps: TStateProps,
+    dispatchProps: TDispatchProps,
+    ownProps: TOwnProps
+  ): TMergedProps
 }
 
-interface Options<TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
-    /**
-     * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
-     * preventing unnecessary updates, assuming that the component is a “pure” component
-     * and does not rely on any input or state other than its props and the selected Redux store’s state.
-     * Defaults to true.
-     * @default true
-     */
-    pure?: boolean;
+interface Options<
+  State = {},
+  TStateProps = {},
+  TOwnProps = {},
+  TMergedProps = {}
+> extends ConnectOptions {
+  /**
+   * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
+   * preventing unnecessary updates, assuming that the component is a “pure” component
+   * and does not rely on any input or state other than its props and the selected Redux store’s state.
+   * Defaults to true.
+   * @default true
+   */
+  pure?: boolean
 
-    /**
-     * When pure, compares incoming store state to its previous value.
-     * @default strictEqual
-     */
-    areStatesEqual?: (nextState: any, prevState: any) => boolean;
+  /**
+   * When pure, compares incoming store state to its previous value.
+   * @default strictEqual
+   */
+  areStatesEqual?: (nextState: State, prevState: State) => boolean
 
-    /**
-     * When pure, compares incoming props to its previous value.
-     * @default shallowEqual
-     */
-    areOwnPropsEqual?: (nextOwnProps: TOwnProps, prevOwnProps: TOwnProps) => boolean;
+  /**
+   * When pure, compares incoming props to its previous value.
+   * @default shallowEqual
+   */
+  areOwnPropsEqual?: (
+    nextOwnProps: TOwnProps,
+    prevOwnProps: TOwnProps
+  ) => boolean
 
-    /**
-     * When pure, compares the result of mapStateToProps to its previous value.
-     * @default shallowEqual
-     */
-    areStatePropsEqual?: (nextStateProps: TStateProps, prevStateProps: TStateProps) => boolean;
+  /**
+   * When pure, compares the result of mapStateToProps to its previous value.
+   * @default shallowEqual
+   */
+  areStatePropsEqual?: (
+    nextStateProps: TStateProps,
+    prevStateProps: TStateProps
+  ) => boolean
 
-    /**
-     * When pure, compares the result of mergeProps to its previous value.
-     * @default shallowEqual
-     */
-    areMergedPropsEqual?: (nextMergedProps: TMergedProps, prevMergedProps: TMergedProps) => boolean;
+  /**
+   * When pure, compares the result of mergeProps to its previous value.
+   * @default shallowEqual
+   */
+  areMergedPropsEqual?: (
+    nextMergedProps: TMergedProps,
+    prevMergedProps: TMergedProps
+  ) => boolean
 }
 
 /**
@@ -197,10 +296,15 @@ interface Options<TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends C
  * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
  *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
  */
-export declare function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = {}>(
-    selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
-    connectOptions?: ConnectOptions & TFactoryOptions
-): AdvancedComponentDecorator<TProps, TOwnProps>;
+export declare function connectAdvanced<
+  S,
+  TProps,
+  TOwnProps,
+  TFactoryOptions = {}
+>(
+  selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
+  connectOptions?: ConnectOptions & TFactoryOptions
+): AdvancedComponentDecorator<TProps, TOwnProps>
 
 /**
  * Initializes a selector function (during each instance's constructor). That selector function is called any time the
@@ -211,69 +315,82 @@ export declare function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = 
  * previous object when appropriate.
  */
 export interface SelectorFactory<S, TProps, TOwnProps, TFactoryOptions> {
-    (dispatch: Dispatch<S>, factoryOptions: TFactoryOptions): Selector<S, TProps, TOwnProps>
+  (dispatch: Dispatch<S>, factoryOptions: TFactoryOptions): Selector<
+    S,
+    TProps,
+    TOwnProps
+  >
 }
 
 export interface Selector<S, TProps, TOwnProps> {
-    (state: S, ownProps: TOwnProps): TProps
+  (state: S, ownProps: TOwnProps): TProps
 }
 
 export interface ConnectOptions {
-    /**
-     * Computes the connector component's displayName property relative to that of the wrapped component. Usually
-     * overridden by wrapper functions.
-     *
-     * @default name => 'ConnectAdvanced('+name+')'
-     * @param componentName
-     */
-    getDisplayName?: (componentName: string) => string
-    /**
-     * Shown in error messages. Usually overridden by wrapper functions.
-     *
-     * @default 'connectAdvanced'
-     */
-    methodName?: string
-    /**
-     * If defined, a property named this value will be added to the props passed to the wrapped component. Its value
-     * will be the number of times the component has been rendered, which can be useful for tracking down unnecessary
-     * re-renders.
-     *
-     * @default undefined
-     */
-    renderCountProp?: string
-    /**
-     * Controls whether the connector component subscribes to redux store state changes. If set to false, it will only
-     * re-render on <code>componentWillReceiveProps</code>.
-     *
-     * @default true
-     */
-    shouldHandleStateChanges?: boolean
-    /**
-     * The key of props/context to get the store. You probably only need this if you are in the inadvisable position of
-     * having multiple stores.
-     *
-     * @default 'store'
-     */
-    storeKey?: string
-    /**
-     * If true, stores a ref to the wrapped component instance and makes it available via getWrappedInstance() method.
-     *
-     * @default false
-     */
-    withRef?: boolean
+  /**
+   * Computes the connector component's displayName property relative to that of the wrapped component. Usually
+   * overridden by wrapper functions.
+   *
+   * @default name => 'ConnectAdvanced('+name+')'
+   * @param componentName
+   */
+  getDisplayName?: (componentName: string) => string
+  /**
+   * Shown in error messages. Usually overridden by wrapper functions.
+   *
+   * @default 'connectAdvanced'
+   */
+  methodName?: string
+  /**
+   * If defined, a property named this value will be added to the props passed to the wrapped component. Its value
+   * will be the number of times the component has been rendered, which can be useful for tracking down unnecessary
+   * re-renders.
+   *
+   * @default undefined
+   */
+  renderCountProp?: string
+  /**
+   * Controls whether the connector component subscribes to redux store state changes. If set to false, it will only
+   * re-render on <code>componentWillReceiveProps</code>.
+   *
+   * @default true
+   */
+  shouldHandleStateChanges?: boolean
+  /**
+   * The key of props/context to get the store. You probably only need this if you are in the inadvisable position of
+   * having multiple stores.
+   *
+   * @default 'store'
+   */
+  storeKey?: string
+  /**
+   * If true, stores a ref to the wrapped component instance and makes it available via getWrappedInstance() method.
+   *
+   * @default false
+   */
+  withRef?: boolean
 }
 
 export interface ProviderProps {
-    /**
-     * The single Redux store in your application.
-     */
-    store?: Store<any>;
-    children?: VNode;
+  /**
+   * The single Redux store in your application.
+   */
+  store?: Store<any>
+  children?: ReactNode
 }
 
 /**
  * Makes the Redux store available to the connect() calls in the component hierarchy below.
  */
-export class Provider extends Component<ProviderProps, {}> {
-    render(props: ProviderProps): VNode
+export class Provider extends Preact.Component<ProviderProps, {}> {
+  render(): ReactNode
 }
+
+/**
+ * Creates a new <Provider> which will set the Redux Store on the passed key of the context. You probably only need this
+ * if you are in the inadvisable position of having multiple stores. You will also need to pass the same storeKey to the
+ * options argument of connect.
+ *
+ * @param storeKey The key of the context on which to set the store.
+ */
+export declare function createProvider(storeKey: string): typeof Provider

--- a/test/ts/preact-redux-test.tsx
+++ b/test/ts/preact-redux-test.tsx
@@ -1,0 +1,1070 @@
+import {
+  Component,
+  VNode,
+  h,
+  render,
+  FunctionalComponent,
+  ComponentConstructor,
+} from 'preact'
+import {
+  Store,
+  Dispatch,
+  ActionCreator,
+  createStore,
+  bindActionCreators,
+  ActionCreatorsMapObject,
+} from 'redux'
+import {
+  connect,
+  Provider,
+  DispatchProp,
+  MapStateToProps,
+  createProvider,
+  Options,
+  Connect,
+} from '../../src/preact-redux'
+
+//
+// Quick Start
+// https://github.com/rackt/react-redux/blob/master/docs/quick-start.md#quick-start
+//
+
+// Test cases written in a way to isolate types and variables and verify the
+// output of `connect` to make sure the signature is what is expected
+
+namespace Empty {
+  interface OwnProps {
+    foo: string
+    dispatch: Dispatch<any>
+  }
+
+  class TestComponent extends Component<OwnProps, {}> {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const Test = connect()(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapState {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+
+  class TestComponent extends Component<OwnProps & StateProps, {}> {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapStateToProps = (_: any) => ({
+    bar: 1,
+  })
+
+  const Test = connect(mapStateToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapStateWithDispatchProp {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+    dispatch: Dispatch<any>
+  }
+
+  class TestComponent extends Component<OwnProps & StateProps, {}> {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapStateToProps = (_: any) => ({
+    bar: 1,
+  })
+
+  const Test = connect(mapStateToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapStateFactory {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+
+  class TestComponent extends Component<OwnProps & StateProps, {}> {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapStateToProps = () => () => ({
+    bar: 1,
+  })
+
+  const Test = connect(mapStateToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapDispatch {
+  interface OwnProps {
+    foo: string
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends Component<OwnProps & DispatchProps, {}> {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapDispatchToProps = () => ({
+    onClick: () => {},
+  })
+
+  const TestNull = connect(null, mapDispatchToProps)(TestComponent)
+
+  const verifyNull = <TestNull foo="bar" />
+
+  const TestUndefined = connect(undefined, mapDispatchToProps)(TestComponent)
+
+  const verifyUndefined = <TestUndefined foo="bar" />
+}
+
+namespace MapStateAndDispatchObject {
+  interface ClickPayload {
+    count: number
+  }
+  const onClick: ActionCreator<ClickPayload> = () => ({ count: 1 })
+  const dispatchToProps = {
+    onClick,
+  }
+
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: ActionCreator<ClickPayload>
+  }
+
+  const mapStateToProps = (_: any, __: OwnProps): StateProps => ({
+    bar: 1,
+  })
+
+  class TestComponent extends Component<
+    OwnProps & StateProps & DispatchProps,
+    {}
+  > {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const Test = connect(mapStateToProps, dispatchToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapDispatchFactory {
+  interface OwnProps {
+    foo: string
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends Component<OwnProps & DispatchProps, {}> {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapDispatchToPropsFactory = () => () => ({
+    onClick: () => {},
+  })
+
+  const TestNull = connect(null, mapDispatchToPropsFactory)(TestComponent)
+
+  const verifyNull = <TestNull foo="bar" />
+
+  const TestUndefined = connect(undefined, mapDispatchToPropsFactory)(
+    TestComponent
+  )
+
+  const verifyUndefined = <TestUndefined foo="bar" />
+}
+
+namespace MapStateAndDispatch {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends Component<
+    OwnProps & StateProps & DispatchProps,
+    {}
+  > {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapStateToProps = () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToProps = () => ({
+    onClick: () => {},
+  })
+
+  const Test = connect(mapStateToProps, mapDispatchToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapStateFactoryAndDispatch {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  const mapStateToPropsFactory = () => () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToProps = () => ({
+    onClick: () => {},
+  })
+
+  class TestComponent extends Component<
+    OwnProps & StateProps & DispatchProps,
+    {}
+  > {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const Test = connect(mapStateToPropsFactory, mapDispatchToProps)(
+    TestComponent
+  )
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapStateFactoryAndDispatchFactory {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  const mapStateToPropsFactory = () => () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToPropsFactory = () => () => ({
+    onClick: () => {},
+  })
+
+  class TestComponent extends Component<
+    OwnProps & StateProps & DispatchProps,
+    {}
+  > {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const Test = connect(mapStateToPropsFactory, mapDispatchToPropsFactory)(
+    TestComponent
+  )
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapStateAndDispatchAndMerge {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends Component<
+    OwnProps & StateProps & DispatchProps,
+    {}
+  > {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapStateToProps = () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToProps = () => ({
+    onClick: () => {},
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps) =>
+    Object.assign({}, stateProps, dispatchProps)
+
+  const Test = connect(mapStateToProps, mapDispatchToProps, mergeProps)(
+    TestComponent
+  )
+
+  const verify = <Test foo="bar" />
+}
+
+namespace MapStateAndOptions {
+  interface State {
+    state: string
+  }
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    dispatch: Dispatch<any>
+  }
+
+  class TestComponent extends Component<
+    OwnProps & StateProps & DispatchProps,
+    {}
+  > {
+    render(): VNode | null {
+      return null
+    }
+  }
+
+  const mapStateToProps = (state: State) => ({
+    bar: 1,
+  })
+
+  const areStatePropsEqual = (next: StateProps, current: StateProps) => true
+
+  const Test = connect<StateProps, DispatchProps, OwnProps, State>(
+    mapStateToProps,
+    null,
+    null,
+    {
+      pure: true,
+      areStatePropsEqual,
+    }
+  )(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+interface CounterState {
+  counter: number
+}
+declare var increment: Function
+
+class Counter extends Component<any, any> {
+  render() {
+    return <button onClick={this.props.onIncrement}>{this.props.value}</button>
+  }
+}
+
+function mapStateToProps(state: CounterState) {
+  return {
+    value: state.counter,
+  }
+}
+
+// Which action creators does it want to receive by props?
+function mapDispatchToProps(dispatch: Dispatch<CounterState>) {
+  return {
+    onIncrement: () => dispatch(increment()),
+  }
+}
+
+connect(mapStateToProps, mapDispatchToProps)(Counter)
+
+@connect(mapStateToProps)
+class CounterContainer extends Component<any, any> {
+  render(): VNode | null {
+    return null
+  }
+}
+
+// Ensure connect's first two arguments can be replaced by wrapper functions
+interface ICounterStateProps {
+  value: number
+}
+interface ICounterDispatchProps {
+  onIncrement: () => void
+}
+// with higher order functions
+connect<ICounterStateProps, ICounterDispatchProps, {}, CounterState>(
+  () => mapStateToProps,
+  () => mapDispatchToProps
+)(Counter)
+// with higher order functions using parameters
+connect<ICounterStateProps, ICounterDispatchProps, {}, CounterState>(
+  (initialState: CounterState, ownProps) => mapStateToProps,
+  (dispatch: Dispatch<CounterState>, ownProps) => mapDispatchToProps
+)(Counter)
+// only first argument
+connect<ICounterStateProps, {}, {}, CounterState>(() => mapStateToProps)(
+  Counter
+)
+// wrap only one argument
+connect<ICounterStateProps, ICounterDispatchProps, {}, CounterState>(
+  mapStateToProps,
+  () => mapDispatchToProps
+)(Counter)
+// with extra arguments
+connect<
+  ICounterStateProps,
+  ICounterDispatchProps,
+  {},
+  ICounterStateProps & ICounterDispatchProps,
+  CounterState
+>(
+  () => mapStateToProps,
+  () => mapDispatchToProps,
+  (s: ICounterStateProps, d: ICounterDispatchProps) => Object.assign({}, s, d),
+  { pure: true }
+)(Counter)
+
+class App extends Component<any, any> {
+  render(): JSX.Element {
+    // ...
+    return null
+  }
+}
+
+const targetEl = document.getElementById('root')
+
+render(<Provider store={store}>{() => <App />}</Provider>, targetEl)
+
+//
+// API
+// https://github.com/rackt/react-redux/blob/master/docs/api.md
+//
+declare var store: Store<TodoState>
+class MyRootComponent extends Component<any, any> {
+  render(): VNode | null {
+    return null
+  }
+}
+class TodoApp extends Component<any, any> {
+  render(): VNode | null {
+    return null
+  }
+}
+interface TodoState {
+  todos: string[] | string
+}
+interface TodoProps {
+  userId: number
+}
+interface DispatchProps {
+  addTodo(userId: number, text: string): void
+  action: Function
+}
+declare var actionCreators: () => {
+  action: Function
+}
+declare var dispatchActionCreators: () => DispatchProps
+declare var addTodo: () => { type: string }
+declare var todoActionCreators: { [type: string]: (...args: any[]) => any }
+declare var counterActionCreators: { [type: string]: (...args: any[]) => any }
+
+render(
+  <Provider store={store}>{() => <MyRootComponent />}</Provider>,
+  document.body
+)
+
+//TODO: for React Router 0.13
+////TODO: error TS2339: Property 'run' does not exist on type 'typeof "react-router"'.
+////TODO: error TS2339: Property 'HistoryLocation' does not exist on type 'typeof "react-router"'.
+//declare var routes: any;
+//Router.run(routes, Router.HistoryLocation, (Handler, routerState) => { // note "routerState" here
+//    ReactDOM.render(
+//        <Provider store={store}>
+//            {/*
+//             //TODO: error TS2339: Property 'routerState' does not exist on type 'RouteProp'.
+//             {() => <Handler routerState={routerState} />} // note "routerState" here: important to pass it down
+//            */}
+//        </Provider>,
+//        document.getElementById('root')
+//    );
+//});
+
+// Inject just dispatch and don't listen to store
+
+const AppWrap = (props: DispatchProp<any> & { children?: VNode }) => <div />
+const WrappedApp = connect()(AppWrap)
+;<WrappedApp />
+
+// Inject dispatch and every field in the global state
+
+connect((state: TodoState) => state)(TodoApp)
+
+// Inject dispatch and todos
+
+function mapStateToProps2(state: TodoState) {
+  return { todos: state.todos }
+}
+
+export default connect(mapStateToProps2)(TodoApp)
+
+// Inject todos and all action creators (addTodo, completeTodo, ...)
+
+//function mapStateToProps(state) {
+//    return { todos: state.todos };
+//}
+
+connect(mapStateToProps2, actionCreators)(TodoApp)
+
+// Inject todos and all action creators (addTodo, completeTodo, ...) as actions
+
+//function mapStateToProps(state) {
+//    return { todos: state.todos };
+//}
+
+function mapDispatchToProps2(dispatch: Dispatch<TodoState>) {
+  return { actions: bindActionCreators(actionCreators, dispatch) }
+}
+
+connect(mapStateToProps2, mapDispatchToProps2)(TodoApp)
+
+// Inject todos and a specific action creator (addTodo)
+
+//function mapStateToProps(state) {
+//    return { todos: state.todos };
+//}
+
+function mapDispatchToProps3(dispatch: Dispatch<TodoState>) {
+  return bindActionCreators({ addTodo }, dispatch)
+}
+
+connect(mapStateToProps2, mapDispatchToProps3)(TodoApp)
+
+// Inject todos, todoActionCreators as todoActions, and counterActionCreators as counterActions
+
+//function mapStateToProps(state) {
+//    return { todos: state.todos };
+//}
+
+function mapDispatchToProps4(dispatch: Dispatch<TodoState>) {
+  return {
+    todoActions: bindActionCreators(todoActionCreators, dispatch),
+    counterActions: bindActionCreators(counterActionCreators, dispatch),
+  }
+}
+
+connect(mapStateToProps2, mapDispatchToProps4)(TodoApp)
+
+// Inject todos, and todoActionCreators and counterActionCreators together as actions
+
+//function mapStateToProps(state) {
+//    return { todos: state.todos };
+//}
+
+function mapDispatchToProps5(dispatch: Dispatch<TodoState>) {
+  return {
+    actions: bindActionCreators(
+      Object.assign({}, todoActionCreators, counterActionCreators),
+      dispatch
+    ),
+  }
+}
+
+connect(mapStateToProps2, mapDispatchToProps5)(TodoApp)
+
+// Inject todos, and all todoActionCreators and counterActionCreators directly as props
+
+//function mapStateToProps(state) {
+//    return { todos: state.todos };
+//}
+
+function mapDispatchToProps6(dispatch: Dispatch<TodoState>) {
+  return bindActionCreators(
+    Object.assign({}, todoActionCreators, counterActionCreators),
+    dispatch
+  )
+}
+
+connect(mapStateToProps2, mapDispatchToProps6)(TodoApp)
+
+// Inject todos of a specific user depending on props
+
+function mapStateToProps3(state: TodoState, ownProps: TodoProps): TodoState {
+  return { todos: state.todos[ownProps.userId] }
+}
+
+connect(mapStateToProps3)(TodoApp)
+
+// Inject todos of a specific user depending on props, and inject props.userId into the action
+
+//function mapStateToProps(state) {
+//    return { todos: state.todos };
+//}
+
+function mergeProps(
+  stateProps: TodoState,
+  dispatchProps: DispatchProps,
+  ownProps: TodoProps
+): DispatchProps & TodoState & TodoProps {
+  return Object.assign({}, ownProps, dispatchProps, {
+    todos: stateProps.todos[ownProps.userId],
+    addTodo: (text: string) => dispatchProps.addTodo(ownProps.userId, text),
+  })
+}
+
+connect(mapStateToProps2, dispatchActionCreators, mergeProps)(MyRootComponent)
+
+//https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14622#issuecomment-279820358
+//Allow for undefined mapStateToProps
+connect(undefined, mapDispatchToProps6)(TodoApp)
+
+interface TestProp {
+  property1: number
+  someOtherProperty?: string
+}
+interface TestState {
+  isLoaded: boolean
+  state1: number
+}
+class TestComponent extends Component<TestProp & DispatchProp<any>, TestState> {
+  render(): JSX.Element {
+    // ...
+    return null
+  }
+}
+const WrappedTestComponent = connect()(TestComponent)
+
+// return value of the connect()(TestComponent) is of the type TestComponent
+let ATestComponent: ComponentConstructor<TestProp, any> = null
+ATestComponent = TestComponent
+ATestComponent = WrappedTestComponent
+
+let anElement: VNode
+;<WrappedTestComponent property1={42} />
+;<ATestComponent property1={42} />
+
+class NonComponent {}
+// this doesn't compile
+//connect()(NonComponent);
+
+// stateless functions
+interface HelloMessageProps {
+  dispatch: Dispatch<any>
+  name: string
+}
+const HelloMessage: FunctionalComponent<HelloMessageProps> = props => {
+  return <div>Hello {props.name}</div>
+}
+let ConnectedHelloMessage = connect()(HelloMessage)
+render(
+  <ConnectedHelloMessage name="Sebastian" />,
+  document.getElementById('content')
+)
+
+// stateless functions that uses mapStateToProps and mapDispatchToProps
+namespace TestStatelessFunctionWithMapArguments {
+  interface GreetingProps {
+    name: string
+    onClick: () => void
+  }
+
+  function Greeting(props: GreetingProps) {
+    return <div>Hello {props.name}</div>
+  }
+
+  const mapStateToProps = (state: any, ownProps: GreetingProps) => {
+    return {
+      name: 'Connected! ' + ownProps.name,
+    }
+  }
+
+  const mapDispatchToProps = (
+    dispatch: Dispatch<any>,
+    ownProps: GreetingProps
+  ) => {
+    return {
+      onClick: () => {
+        dispatch({ type: 'GREETING', name: ownProps.name })
+      },
+    }
+  }
+
+  const ConnectedGreeting = connect(mapStateToProps, mapDispatchToProps)(
+    Greeting
+  )
+}
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/8787
+namespace TestTOwnPropsInference {
+  interface OwnProps {
+    own: string
+  }
+
+  interface StateProps {
+    state: string
+  }
+
+  class OwnPropsComponent extends Component<
+    StateProps & OwnProps & DispatchProp<any>,
+    {}
+  > {
+    render() {
+      return <div />
+    }
+  }
+
+  function mapStateToPropsWithoutOwnProps(state: any): StateProps {
+    return { state: 'string' }
+  }
+
+  function mapStateToPropsWithOwnProps(
+    state: any,
+    ownProps: OwnProps
+  ): StateProps {
+    return { state: 'string' }
+  }
+
+  const ConnectedWithoutOwnProps = connect(mapStateToPropsWithoutOwnProps)(
+    OwnPropsComponent
+  )
+  const ConnectedWithOwnProps = connect(mapStateToPropsWithOwnProps)(
+    OwnPropsComponent
+  )
+  const ConnectedWithTypeHint = connect<StateProps, void, OwnProps>(
+    mapStateToPropsWithoutOwnProps
+  )(OwnPropsComponent)
+
+  // This should not compile, which is good.
+  // h(ConnectedWithoutOwnProps, { anything: 'goes!' });
+
+  // This compiles, as expected.
+  h(ConnectedWithOwnProps, { own: 'string' })
+
+  // This should not compile, which is good.
+  // h(ConnectedWithOwnProps, { anything: 'goes!' });
+
+  // This compiles, as expected.
+  h(ConnectedWithTypeHint, { own: 'string' })
+
+  // This should not compile, which is good.
+  // h(ConnectedWithTypeHint, { anything: 'goes!' });
+
+  interface AllProps {
+    own: string
+    state: string
+  }
+
+  class AllPropsComponent extends Component<AllProps & DispatchProp<any>, {}> {
+    render() {
+      return <div />
+    }
+  }
+
+  type PickedOwnProps = Pick<AllProps, 'own'>
+  type PickedStateProps = Pick<AllProps, 'state'>
+
+  const mapStateToPropsForPicked: MapStateToProps<
+    PickedStateProps,
+    PickedOwnProps,
+    {}
+  > = (state: any): PickedStateProps => {
+    return { state: 'string' }
+  }
+  const ConnectedWithPickedOwnProps = connect(mapStateToPropsForPicked)(
+    AllPropsComponent
+  )
+  ;<ConnectedWithPickedOwnProps own="blah" />
+}
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16021
+namespace TestMergedPropsInference {
+  interface StateProps {
+    state: string
+  }
+
+  interface DispatchProps {
+    dispatch: string
+  }
+
+  interface OwnProps {
+    own: string
+  }
+
+  interface MergedProps {
+    merged: string
+  }
+
+  class MergedPropsComponent extends Component<MergedProps, {}> {
+    render() {
+      return <div />
+    }
+  }
+
+  function mapStateToProps(state: any): StateProps {
+    return { state: 'string' }
+  }
+
+  function mapDispatchToProps(dispatch: Dispatch<any>): DispatchProps {
+    return { dispatch: 'string' }
+  }
+
+  const ConnectedWithOwnAndState: ComponentConstructor<OwnProps, {}> = connect<
+    StateProps,
+    void,
+    OwnProps,
+    MergedProps
+  >(mapStateToProps, undefined, (stateProps: StateProps) => ({
+    merged: 'merged',
+  }))(MergedPropsComponent)
+
+  const ConnectedWithOwnAndDispatch: ComponentConstructor<
+    OwnProps,
+    {}
+  > = connect<void, DispatchProps, OwnProps, MergedProps>(
+    undefined,
+    mapDispatchToProps,
+    (stateProps: undefined, dispatchProps: DispatchProps) => ({
+      merged: 'merged',
+    })
+  )(MergedPropsComponent)
+
+  const ConnectedWithOwn: ComponentConstructor<OwnProps, {}> = connect<
+    void,
+    void,
+    OwnProps,
+    MergedProps
+  >(undefined, undefined, () => ({
+    merged: 'merged',
+  }))(MergedPropsComponent)
+}
+
+namespace Issue16652 {
+  interface PassedProps {
+    commentIds: string[]
+  }
+
+  interface GeneratedStateProps {
+    comments: ({ id: string } | undefined)[]
+  }
+
+  class CommentList extends Component<
+    PassedProps & GeneratedStateProps & DispatchProp<any>,
+    {}
+  > {
+    render() {
+      return <div />
+    }
+  }
+
+  const mapStateToProps = (
+    state: any,
+    ownProps: PassedProps
+  ): GeneratedStateProps => {
+    return {
+      comments: ownProps.commentIds.map(id => ({ id })),
+    }
+  }
+
+  const ConnectedCommentList = connect<GeneratedStateProps, {}, PassedProps>(
+    mapStateToProps
+  )(CommentList)
+  ;<ConnectedCommentList commentIds={['a', 'b', 'c']} />
+}
+
+namespace Issue15463 {
+  interface ISpinnerProps {
+    showGlobalSpinner: boolean
+  }
+  class SpinnerClass extends Component<
+    ISpinnerProps & DispatchProp<any>,
+    undefined
+  > {
+    render() {
+      return <div />
+    }
+  }
+
+  export const Spinner = connect((state: any) => {
+    return { showGlobalSpinner: true }
+  })(SpinnerClass)
+  ;<Spinner />
+}
+
+namespace RemoveInjectedAndPassOnRest {
+  interface TProps {
+    showGlobalSpinner: boolean
+    foo: string
+  }
+  class SpinnerClass extends Component<TProps & DispatchProp<any>, {}> {
+    render() {
+      return <div />
+    }
+  }
+
+  export const Spinner = connect((state: any) => {
+    return { showGlobalSpinner: true }
+  })(SpinnerClass)
+  ;<Spinner foo="bar" />
+}
+
+namespace TestControlledComponentWithoutDispatchProp {
+  interface MyState {
+    count: number
+  }
+
+  interface MyProps {
+    label: string
+    // `dispatch` is optional, but setting it to anything
+    // other than Dispatch<T> will cause an error
+    //
+    // dispatch: Dispatch<any>; // OK
+    // dispatch: number; // ERROR
+  }
+
+  function mapStateToProps(state: MyState) {
+    return {
+      label: `The count is ${state.count}`,
+    }
+  }
+
+  class MyComponent extends Component<MyProps, {}> {
+    render() {
+      return <span>{this.props.label}</span>
+    }
+  }
+
+  const MyFuncComponent = (props: MyProps) => <span>{props.label}</span>
+
+  const MyControlledComponent = connect(mapStateToProps)(MyComponent)
+  const MyControlledFuncComponent = connect(mapStateToProps)(MyFuncComponent)
+}
+
+namespace TestDispatchToPropsAsObject {
+  const onClick: ActionCreator<{}> = null
+  const mapStateToProps = (state: any) => {
+    return {
+      title: state.app.title as string,
+    }
+  }
+  const dispatchToProps = {
+    onClick,
+  }
+
+  type Props = { title: string } & typeof dispatchToProps
+  const HeaderComponent: FunctionalComponent<Props> = props => {
+    return <h1>{props.title}</h1>
+  }
+
+  const Header = connect(mapStateToProps, dispatchToProps)(HeaderComponent)
+  ;<Header />
+}
+
+namespace TestWrappedComponent {
+  type InnerProps = {
+    name: string
+  }
+  const Inner: FunctionalComponent<InnerProps> = props => {
+    return <h1>{props.name}</h1>
+  }
+
+  const mapStateToProps = (state: any) => {
+    return {
+      name: 'Connected',
+    }
+  }
+  const Connected = connect(mapStateToProps)(Inner)
+
+  // `Inner` and `Connected.WrappedComponent` require explicit `name` prop
+  const TestInner = (props: any) => <Inner name="Inner" />
+  const TestWrapped = (props: any) => (
+    <Connected.WrappedComponent name="Wrapped" />
+  )
+  // `Connected` does not require explicit `name` prop
+  const TestConnected = (props: any) => <Connected />
+}
+
+namespace TestCreateProvider {
+  const STORE_KEY = 'myStore'
+
+  const MyStoreProvider = createProvider(STORE_KEY)
+
+  const myStoreConnect: Connect = function(
+    mapStateToProps?: any,
+    mapDispatchToProps?: any,
+    mergeProps?: any,
+    options: Options = {}
+  ) {
+    options.storeKey = STORE_KEY
+    return connect(mapStateToProps, mapDispatchToProps, mergeProps, options)
+  }
+
+  interface State {
+    a: number
+  }
+  const store = createStore<State>(() => ({ a: 1 }))
+  const myStore = createStore<State>(() => ({ a: 2 }))
+
+  interface AProps {
+    a: number
+  }
+  const A = (props: AProps) => <h1>A is {props.a}</h1>
+  const A1 = connect<AProps, {}, {}, State>(state => state)(A)
+  const A2 = myStoreConnect<AProps, {}, {}, State>(state => state)(A)
+
+  const Combined = () => (
+    <Provider store={store}>
+      <MyStoreProvider store={myStore}>
+        <A1 />
+        <A2 />
+      </MyStoreProvider>
+    </Provider>
+  )
+
+  // This renders:
+  // <h1>A is 1</h1>
+  // <h1>A is 2</h1>
+  render(<Combined />, document.body)
+}

--- a/test/ts/tsconfig.json
+++ b/test/ts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": false,
+    "strictFunctionTypes": false,
+    "moduleResolution": "node",
+    "typeRoots": ["../../"],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "jsx": "react",
+    "jsxFactory": "h"
+  },
+  "files": ["preact-redux-test.tsx", "../../src/preact-redux.d.ts"]
+}


### PR DESCRIPTION
From https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-redux
Almost 1-1 (only tests changed a little). Should be pretty easy to port newer version of typings.

**Known Issue:** (which is true for this also)
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-redux/index.d.ts#L14-L19

There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes 
they are decorating. Due to this, if you are using @connect() decorator in your code,
you will see a bunch of errors from TypeScript. The current workaround is to use connect() as a function call on
a separate line instead of as a decorator. Discussed in this github issue:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796

