### PR TITLE
Externalize preact-context

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,8 @@
   "homepage": "https://github.com/developit/preact-redux",
   "peerDependencies": {
     "preact": "<10",
-    "redux": ">=2"
-  },
-  "dependencies": {
-    "preact-context": "^1.1.3"
+    "redux": ">=2",
+    "preact-context": ">=1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",
@@ -76,6 +74,7 @@
     "npm-run-all": "^4.0.2",
     "phantomjs-prebuilt": "^2.1.14",
     "preact": "^8.1.0",
+    "preact-context": "^1.1.3",
     "pretty-bytes-cli": "^2.0.0",
     "react-redux": "^6.0.1",
     "redux": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "preact": ">=3",
     "redux": ">=2"
   },
+  "dependencies": {
+    "preact-context": "^1.1.3"
+  },
   "devDependencies": {
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.4.3",
@@ -73,7 +76,6 @@
     "npm-run-all": "^4.0.2",
     "phantomjs-prebuilt": "^2.1.14",
     "preact": "^8.1.0",
-    "preact-context": "^1.1.3",
     "pretty-bytes-cli": "^2.0.0",
     "react-redux": "^6.0.1",
     "redux": "^4.0.0",


### PR DESCRIPTION
Depend on preact-context instead of inlining it, so that folks don't end up with duplicate copies of the library.